### PR TITLE
URL Cleanup

### DIFF
--- a/rabbitmq-defaults
+++ b/rabbitmq-defaults
@@ -2,7 +2,7 @@
 ##  The contents of this file are subject to the Mozilla Public License
 ##  Version 1.1 (the "License"); you may not use this file except in
 ##  compliance with the License. You may obtain a copy of the License
-##  at http://www.mozilla.org/MPL/
+##  at https://www.mozilla.org/MPL/
 ##
 ##  Software distributed under the License is distributed on an "AS IS"
 ##  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/rabbitmq-env
+++ b/rabbitmq-env
@@ -2,7 +2,7 @@
 ##  The contents of this file are subject to the Mozilla Public License
 ##  Version 1.1 (the "License"); you may not use this file except in
 ##  compliance with the License. You may obtain a copy of the License
-##  at http://www.mozilla.org/MPL/
+##  at https://www.mozilla.org/MPL/
 ##
 ##  Software distributed under the License is distributed on an "AS IS"
 ##  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.mozilla.org/MPL/ with 2 occurrences migrated to:  
  https://www.mozilla.org/MPL/ ([https](https://www.mozilla.org/MPL/) result 301).